### PR TITLE
Remove ROS_INFO in x264Publisher destructor

### DIFF
--- a/src/x264_publisher.cpp
+++ b/src/x264_publisher.cpp
@@ -22,8 +22,6 @@ namespace x264_image_transport {
 	
 	x264Publisher::~x264Publisher()
 	{
-		ROS_INFO("x264Publisher::~x264Publisher()");
-		
          pthread_mutex_lock (&mutex_);
 
          memory_cleanup();


### PR DESCRIPTION
Otherwise, this prints out a (useless) message on shutdown for all nodelets in the system with the plugin installed.